### PR TITLE
Fixing development environment 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       dockerfile: ./dev.Dockerfile
     volumes: 
       - .:/var/www/gateway
+      - /var/www/gateway/node_modules
     restart: always
     hostname: maps
     env_file:


### PR DESCRIPTION
# Description
The development docker-compose file needed a data volume for the npm packages to not need an external installation. 