### PR TITLE
Feature/validate points

### DIFF
--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -10,6 +10,7 @@ export class AreaDto {
     newAreaDto.description = area.description;
     newAreaDto.type = area.type;
     newAreaDto.coordinates = area.coordinates;
+    newAreaDto.validated = area.validated;
 
     return newAreaDto;
   }
@@ -21,4 +22,5 @@ export class AreaDto {
   type = 'Polygon';
   coordinates: number[][][];
   medias: MediaRelationDocument[] = []; //initialize as empty list
+  validated: boolean;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -11,6 +11,7 @@ export class AreaDto {
     newAreaDto.type = area.type;
     newAreaDto.coordinates = area.coordinates;
     newAreaDto.validated = area.validated;
+    newAreaDto.member = area.member;
 
     return newAreaDto;
   }
@@ -23,4 +24,5 @@ export class AreaDto {
   coordinates: number[][][];
   medias: MediaRelationDocument[] = []; //initialize as empty list
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -12,7 +12,6 @@ export class AreaDto {
     newAreaDto.coordinates = area.coordinates;
     newAreaDto.validated = area.validated;
     newAreaDto.member = area.member;
-    newAreaDto.color = area.color;
 
     return newAreaDto;
   }
@@ -26,5 +25,4 @@ export class AreaDto {
   medias: MediaRelationDocument[] = []; //initialize as empty list
   validated: boolean;
   member: string;
-  color: string;
 }

--- a/src/mapas/dto/area.dto.ts
+++ b/src/mapas/dto/area.dto.ts
@@ -12,6 +12,7 @@ export class AreaDto {
     newAreaDto.coordinates = area.coordinates;
     newAreaDto.validated = area.validated;
     newAreaDto.member = area.member;
+    newAreaDto.color = area.color;
 
     return newAreaDto;
   }
@@ -25,4 +26,5 @@ export class AreaDto {
   medias: MediaRelationDocument[] = []; //initialize as empty list
   validated: boolean;
   member: string;
+  color: string;
 }

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -4,7 +4,6 @@ export class CreateAreaDto {
   coordinates: Coordinates[];
   validated: boolean;
   member: string;
-  color: string;
 }
 
 class Coordinates {

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -2,6 +2,7 @@ export class CreateAreaDto {
   title: string;
   description?: string;
   coordinates: Coordinates[];
+  validated: boolean;
 }
 
 class Coordinates {

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -4,6 +4,7 @@ export class CreateAreaDto {
   coordinates: Coordinates[];
   validated: boolean;
   member: string;
+  color: string;
 }
 
 class Coordinates {

--- a/src/mapas/dto/create-area.dto.ts
+++ b/src/mapas/dto/create-area.dto.ts
@@ -3,6 +3,7 @@ export class CreateAreaDto {
   description?: string;
   coordinates: Coordinates[];
   validated: boolean;
+  member: string;
 }
 
 class Coordinates {

--- a/src/mapas/dto/create-point.dto.ts
+++ b/src/mapas/dto/create-point.dto.ts
@@ -4,4 +4,5 @@ export class CreatePointDto {
   latitude: number;
   longitude: number;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/create-point.dto.ts
+++ b/src/mapas/dto/create-point.dto.ts
@@ -3,4 +3,5 @@ export class CreatePointDto {
   description?: string;
   latitude: number;
   longitude: number;
+  validated: boolean;
 }

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -10,6 +10,7 @@ export class PointDto {
     newPointDto.description = point.description;
     newPointDto.coordinates = point.coordinates;
     newPointDto.validated = point.validated;
+    newPointDto.member = point.member;
 
     return newPointDto;
   }
@@ -18,6 +19,7 @@ export class PointDto {
   id: string;
   title: string;
   validated: boolean;
+  member: string;
   description?: string;
   type = 'Point';
   coordinates: number[];

--- a/src/mapas/dto/point.dto.ts
+++ b/src/mapas/dto/point.dto.ts
@@ -9,6 +9,7 @@ export class PointDto {
     newPointDto.title = point.title;
     newPointDto.description = point.description;
     newPointDto.coordinates = point.coordinates;
+    newPointDto.validated = point.validated;
 
     return newPointDto;
   }
@@ -16,6 +17,7 @@ export class PointDto {
   // these values will be initialized from a PointDocument
   id: string;
   title: string;
+  validated: boolean;
   description?: string;
   type = 'Point';
   coordinates: number[];

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -2,4 +2,5 @@ export class UpdateAreaDto {
   id: string;
   title?: string;
   description?: string;
+  validated: boolean;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -4,5 +4,4 @@ export class UpdateAreaDto {
   description?: string;
   validated: boolean;
   member: string;
-  color: string;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -3,4 +3,5 @@ export class UpdateAreaDto {
   title?: string;
   description?: string;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/dto/update-area.dto.ts
+++ b/src/mapas/dto/update-area.dto.ts
@@ -4,4 +4,5 @@ export class UpdateAreaDto {
   description?: string;
   validated: boolean;
   member: string;
+  color: string;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -2,4 +2,5 @@ export class UpdatePointDto {
   id: string;
   title?: string;
   description?: string;
+  validated: boolean;
 }

--- a/src/mapas/dto/update-point.dto.ts
+++ b/src/mapas/dto/update-point.dto.ts
@@ -3,4 +3,5 @@ export class UpdatePointDto {
   title?: string;
   description?: string;
   validated: boolean;
+  member: string;
 }

--- a/src/mapas/entities/area.schema.ts
+++ b/src/mapas/entities/area.schema.ts
@@ -22,9 +22,6 @@ export class Area {
 
   @Prop()
   member: string;
-
-  @Prop()
-  color: string;
 }
 
 export const AreaSchema = SchemaFactory.createForClass(Area);

--- a/src/mapas/entities/area.schema.ts
+++ b/src/mapas/entities/area.schema.ts
@@ -19,6 +19,9 @@ export class Area {
 
   @Prop()
   validated: boolean;
+
+  @Prop()
+  member: string;
 }
 
 export const AreaSchema = SchemaFactory.createForClass(Area);

--- a/src/mapas/entities/area.schema.ts
+++ b/src/mapas/entities/area.schema.ts
@@ -16,6 +16,9 @@ export class Area {
 
   @Prop()
   coordinates: number[][][];
+
+  @Prop()
+  validated: boolean;
 }
 
 export const AreaSchema = SchemaFactory.createForClass(Area);

--- a/src/mapas/entities/area.schema.ts
+++ b/src/mapas/entities/area.schema.ts
@@ -22,6 +22,9 @@ export class Area {
 
   @Prop()
   member: string;
+
+  @Prop()
+  color: string;
 }
 
 export const AreaSchema = SchemaFactory.createForClass(Area);

--- a/src/mapas/entities/point.schema.ts
+++ b/src/mapas/entities/point.schema.ts
@@ -19,6 +19,9 @@ export class Point {
 
   @Prop()
   validated: boolean;
+
+  @Prop()
+  member: string;
 }
 
 export const PointSchema = SchemaFactory.createForClass(Point);

--- a/src/mapas/entities/point.schema.ts
+++ b/src/mapas/entities/point.schema.ts
@@ -16,6 +16,9 @@ export class Point {
 
   @Prop()
   coordinates: number[];
+
+  @Prop()
+  validated: boolean;
 }
 
 export const PointSchema = SchemaFactory.createForClass(Point);

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -39,6 +39,7 @@ export class MapasService {
     const point = new this.pointModel({
       title: createPointDto.title,
       validated: createPointDto.validated,
+      member: createPointDto.member,
       description: createPointDto.description,
       coordinates: [createPointDto.longitude, createPointDto.latitude],
     });
@@ -65,6 +66,7 @@ export class MapasService {
     point.description = updatePointDto.description || point.description;
     point.title = updatePointDto.title || point.title;
     point.validated = updatePointDto.validated || point.validated;
+    point.member = updatePointDto.member || point.member;
 
     try {
       const result = point.save();
@@ -131,7 +133,8 @@ export class MapasService {
       title: createAreaDto.title,
       description: createAreaDto.description,
       coordinates: [coordinates],
-      validated: createAreaDto.validated
+      validated: createAreaDto.validated,
+      member: createAreaDto.member
     });
 
     try {
@@ -156,6 +159,7 @@ export class MapasService {
     area.description = updateAreaDto.description || area.description;
     area.title = updateAreaDto.title || area.title;
     area.validated = updateAreaDto.validated || area.validated;
+    area.member = updateAreaDto.member || area.member;
 
     try {
       const result = area.save();

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -38,6 +38,7 @@ export class MapasService {
   async createPoint(createPointDto: CreatePointDto) {
     const point = new this.pointModel({
       title: createPointDto.title,
+      validated: createPointDto.validated,
       description: createPointDto.description,
       coordinates: [createPointDto.longitude, createPointDto.latitude],
     });
@@ -63,6 +64,7 @@ export class MapasService {
 
     point.description = updatePointDto.description || point.description;
     point.title = updatePointDto.title || point.title;
+    point.validated = updatePointDto.validated || point.validated
 
     try {
       const result = point.save();

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -134,8 +134,7 @@ export class MapasService {
       description: createAreaDto.description,
       coordinates: [coordinates],
       validated: createAreaDto.validated,
-      member: createAreaDto.member,
-      color: createAreaDto.color,
+      member: createAreaDto.member
     });
 
     try {
@@ -161,7 +160,6 @@ export class MapasService {
     area.title = updateAreaDto.title || area.title;
     area.validated = updateAreaDto.validated || area.validated;
     area.member = updateAreaDto.member || area.member;
-    area.color = updateAreaDto.color || area.color;
 
     try {
       const result = area.save();

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -64,7 +64,7 @@ export class MapasService {
 
     point.description = updatePointDto.description || point.description;
     point.title = updatePointDto.title || point.title;
-    point.validated = updatePointDto.validated || point.validated
+    point.validated = updatePointDto.validated || point.validated;
 
     try {
       const result = point.save();
@@ -131,6 +131,7 @@ export class MapasService {
       title: createAreaDto.title,
       description: createAreaDto.description,
       coordinates: [coordinates],
+      validated: createAreaDto.validated
     });
 
     try {
@@ -154,6 +155,7 @@ export class MapasService {
 
     area.description = updateAreaDto.description || area.description;
     area.title = updateAreaDto.title || area.title;
+    area.validated = updateAreaDto.validated || area.validated;
 
     try {
       const result = area.save();

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -134,7 +134,8 @@ export class MapasService {
       description: createAreaDto.description,
       coordinates: [coordinates],
       validated: createAreaDto.validated,
-      member: createAreaDto.member
+      member: createAreaDto.member,
+      color: createAreaDto.color,
     });
 
     try {
@@ -160,6 +161,7 @@ export class MapasService {
     area.title = updateAreaDto.title || area.title;
     area.validated = updateAreaDto.validated || area.validated;
     area.member = updateAreaDto.member || area.member;
+    area.color = updateAreaDto.color || area.color;
 
     try {
       const result = area.save();

--- a/src/mapas/mapas.service.ts
+++ b/src/mapas/mapas.service.ts
@@ -134,7 +134,7 @@ export class MapasService {
       description: createAreaDto.description,
       coordinates: [coordinates],
       validated: createAreaDto.validated,
-      member: createAreaDto.member
+      member: createAreaDto.member,
     });
 
     try {

--- a/test/mapas/mapas.controller.spec.ts
+++ b/test/mapas/mapas.controller.spec.ts
@@ -56,6 +56,8 @@ describe('MapasController', () => {
         description: 'teste',
         latitude: 0,
         longitude: 0,
+        validated: false,
+        member: 'memberid',
       }),
     ).toStrictEqual(id);
   });
@@ -118,6 +120,8 @@ describe('MapasController', () => {
         id: '123',
         title: 'teste',
         description: 'teste',
+        validated: false,
+        member: 'memberid',
       }),
     ).toStrictEqual(id);
   });
@@ -143,6 +147,8 @@ describe('MapasController', () => {
       await controller.createArea({
         title: 'teste',
         description: 'teste',
+        validated: false,
+        member: 'memberid',
         coordinates: [
           {
             latitude: 0,
@@ -218,6 +224,8 @@ describe('MapasController', () => {
         id: '123',
         title: 'teste',
         description: 'teste',
+        validated: false,
+        member: 'memberid',
       }),
     ).toStrictEqual(id);
   });

--- a/test/mapas/mapas.service.spec.ts
+++ b/test/mapas/mapas.service.spec.ts
@@ -18,6 +18,8 @@ describe('MapasService', () => {
     description: 'teste',
     latitude: 0,
     longitude: 0,
+    validated: false,
+    member: 'memberid',
   };
 
   const defaultPointDto = {
@@ -26,6 +28,8 @@ describe('MapasService', () => {
     type: 'Point',
     coordinates: [0, 0],
     medias: [],
+    validated: false,
+    member: 'memberid',
   };
 
   const defaultPoint = {
@@ -33,6 +37,8 @@ describe('MapasService', () => {
     description: 'teste',
     coordinates: [0, 0],
     type: 'Point',
+    validated: false,
+    member: 'memberid',
   };
 
   const defaultArea = {
@@ -40,6 +46,8 @@ describe('MapasService', () => {
     description: 'teste',
     type: 'Polygon',
     medias: [],
+    validated: false,
+    member: 'memberid',
     coordinates: [
       {
         latitude: 0,
@@ -165,6 +173,8 @@ describe('MapasService', () => {
         id: '123',
         title: 'new title',
         description: 'new description',
+        validated: false,
+        member: 'memberid',
       }),
     ).toBe('123');
   });
@@ -452,6 +462,8 @@ describe('MapasService', () => {
         id: '123',
         title: 'new title',
         description: 'new description',
+        validated: false,
+        member: 'memberid',
       }),
     ).toBe('123');
   });


### PR DESCRIPTION
Co-authored-by: Gian Medeiros <gianmedeiros14@gmail.com>

## Motivação
Para a criação, edição e visualização de pontos disponíveis no banco de dados, era necessário um campo que indicasse o estado de validação do ponto.

- Usuários comuns podem criar pontos, porém os pontos criados devem ser validados por um usuário **Administrador** para que fiquem disponíveis para todos os usuários.
- Pontos não validados devem aparecer na cor amarela, e apenas para o Líder da comunidade
- Essa validação deve ser feita no front-end com base no estado de validação do Ponto/Área retornado pelo back-end 

## Mudanças feitas
- Foi adicionado um campo **Validated** nas Entidades de pontos e áreas
- Adicionado validated nas chamadas das funções de POST e PUT de pontos e áreas
- O campo Validated é booleano

## Tarefa relacionada
[#74](https://github.com/fga-eps-mds/2021-2-Cartografia-social-Doc/issues/74) e [#114](https://github.com/fga-eps-mds/2021-2-Cartografia-social-Doc/issues/114) 